### PR TITLE
Upgrade Python and Django dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy3']
-        django-version: ['2.2', '3.0', '3.1', '3.2']
+        django-version: ['2.2', '3.1', '3.2']
 
     steps:
       - name: Checkout Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Removed
 - Dropped support for Python 3.5 and 3.6
+- Dropped support for Django 3.0
 ### Added
 - Added support for Python 3.9 and 3.10
 - Added support for Django 3.2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build-and-test actions status](https://github.com/anexia-it/django-cleanhtmlfield/workflows/Module tests/badge.svg)](https://github.com/anexia-it/django-cleanhtmlfield/actions)
 
 Django CleanHtmlField is a simple Django application (supporting Django
-2.2, 3.0, 3.1 and 3.2) that defines an `HTMLField` that automatically
+2.2, 3.1 and 3.2) that defines an `HTMLField` that automatically
 removes potentially malicious content. This app should work with Python
 3.7+.
 
@@ -182,7 +182,7 @@ a matrix showing the guaranteed and tested compatibility.
 django-cleanhtmlfield Version | Django Versions | Django Rest Framework Versions | Python |
 --------------------------------- | --------------- | ------------------------------ | ------ |
 1.1 | 2.2, 3.0, 3.1 | 3.6 - 3.11 | 3.5 - 3.8
-Unreleased | 2.2, 3.0, 3.1, 3.2 | 3.6 - 3.11 | 3.7 - 3.10
+Unreleased | 2.2, 3.1, 3.2 | 3.6 - 3.11 | 3.7 - 3.10
 
 # License
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This removes support for Python 3.5 and 3.6, adds official support for 3.9 and 3.10, and Django 3.2.
I've also included changelog updates to so we can immediately release version 1.2.0